### PR TITLE
Fix GitHub link on About page

### DIFF
--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -310,7 +310,7 @@
         <item>https://behance.net/JapanYoshi</item>
 <!--    <item>https://dribbble.com/yourusername</item>
         <item>https://facebook.com/yourusername</item>-->
-        <item>https://github.com/yourusername</item>
+        <item>https://github.com/JapanYoshi</item>
 <!--    <item>https://instagram.com/yourusername</item>
         <item>https://pinterest.com/yourusername</item>
         <item>https://twitter.com/yourusername</item>


### PR DESCRIPTION
The GitHub link in the app's about section would previously lead to the profile of user `Yourusername`.